### PR TITLE
fix: Handle non-string API responses in callbacks

### DIFF
--- a/gptel-magit.el
+++ b/gptel-magit.el
@@ -124,8 +124,9 @@ Invokes CALLBACK with the generated message when done."
       :system gptel-magit-commit-prompt
       :context nil
       :callback (lambda (response _info)
-                  (let ((msg (gptel-magit--format-commit-message response)))
-                    (funcall callback msg))))))
+                  (when (stringp response)
+                    (let ((msg (gptel-magit--format-commit-message response)))
+                      (funcall callback msg)))))))
 
 (defun gptel-magit-generate-message ()
   "Generate a commit message when in the git commit buffer."
@@ -168,7 +169,8 @@ Uses ARGS from transient mode."
     :system gptel-magit-diff-explain-prompt
     :context nil
     :callback (lambda (response _info)
-                (gptel-magit--show-diff-explain response)))
+                (when (stringp response)
+                  (gptel-magit--show-diff-explain response))))
   (message "magit-gptel: Explaining diff..."))
 
 (defun gptel-magit-diff-explain ()


### PR DESCRIPTION
Ensures that the response from `gptel-request` is a string before processing it in the callbacks for commit message generation and diff explanation.

This prevents potential errors if the API request is cancelled or fails resulting in a non-string response, or if the response is of different type as mentioned in [gptel-request doc][1].

[1]: https://github.com/karthink/gptel/blob/b0f80b1ed9608f273753135bb6b42b3527512962/gptel.el#L2300-L2339