### PR TITLE
Improve formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,103 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  byte-compile:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        emacs_version:
+          - "29.4"
+          - "30.1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Emacs
+        uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs_version }}
+
+      - name: Install dependencies
+        run: |
+          emacs --batch \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
+            --eval "(package-refresh-contents)" \
+            --eval "(package-install 'gptel)" \
+            --eval "(package-install 'magit)"
+
+      - name: Byte-compile
+        run: |
+          # transient 20260617's byte-compiled file can retain a runtime call to
+          # compat's static-when macro, which can make loading Magit fail with
+          # "Invalid function: static-when" while compiling this package.  Load
+          # transient from source until the upstream package is fixed.
+          find ~/.emacs.d/elpa -path '*/transient-*/transient.elc' -delete
+          emacs --batch \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
+            -f batch-byte-compile gptel-magit.el
+
+  checkdoc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Emacs
+        uses: purcell/setup-emacs@master
+        with:
+          version: "30.1"
+
+      - name: Run checkdoc
+        run: |
+          emacs --batch \
+            --eval "(require 'checkdoc)" \
+            --eval "(setq checkdoc-force-docstrings-flag t)" \
+            --eval "(setq checkdoc-force-history-flag nil)" \
+            --eval "(setq checkdoc-spellcheck-documentation-flag nil)" \
+            --eval "(with-current-buffer (find-file-noselect \"gptel-magit.el\") \
+                      (let ((err (or (checkdoc-comments) \
+                                     (checkdoc-start) \
+                                     (checkdoc-message-text) \
+                                     (checkdoc-rogue-spaces)))) \
+                        (when err \
+                          (message \"Checkdoc error: %s\" (checkdoc-error-text err)) \
+                          (kill-emacs 1))))"
+
+  package-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Emacs
+        uses: purcell/setup-emacs@master
+        with:
+          version: "30.1"
+
+      - name: Install package-lint
+        run: |
+          emacs --batch \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
+            --eval "(package-refresh-contents)" \
+            --eval "(package-install 'package-lint)"
+
+      - name: Run package-lint
+        run: |
+          emacs --batch \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
+            --eval "(require 'package-lint)" \
+            -f package-lint-batch-and-exit gptel-magit.el

--- a/README.org
+++ b/README.org
@@ -9,6 +9,7 @@ LLM-powered functionality.
 Functionality is provided for:
 
 - Generating commit messages
+- Providing optional rationale to guide generated commit messages
 - Explaining diffs
 
 * Installation
@@ -32,6 +33,18 @@ You can generate a commit message in two ways:
    commit with a pre-generated message.
 2. In an already started git-commit buffer, you can press =M-g= to
    generate a message.
+
+To provide extra context about why the change was made, generate with a
+rationale instead:
+
+1. In the magit transient commit buffer, press =r= to enter a rationale
+   before creating the commit.
+2. In an already started git-commit buffer, press =M-r= to enter a
+   rationale before generating the message.
+
+Submit the rationale buffer with =C-c C-c=, or cancel it with =C-c C-k=.
+Leaving the buffer empty generates the commit message without additional
+rationale.
 
 ** Diff explanation
 

--- a/README.org
+++ b/README.org
@@ -10,6 +10,7 @@ Functionality is provided for:
 
 - Generating commit messages
 - Providing optional rationale to guide generated commit messages
+- Generating annotated tag messages from the diff between tags
 - Explaining diffs
 
 * Installation
@@ -45,6 +46,19 @@ rationale instead:
 Submit the rationale buffer with =C-c C-c=, or cancel it with =C-c C-k=.
 Leaving the buffer empty generates the commit message without additional
 rationale.
+
+** Tag messages
+
+From the magit tag transient, press =g= to create an annotated tag with a
+generated message.  This prompts for the new tag, the target revision,
+and the previous tag to summarize from.  The generated message is opened
+for review before the tag is created.
+
+Press =R= in the tag transient to provide rationale before generating the
+tag message.  Magit's existing =r= release-tag binding is left unchanged.
+
+In an already opened =TAG_EDITMSG= buffer, =M-g= and =M-r= generate a tag
+message using the diff from a prompted previous tag to =HEAD=.
 
 ** Diff explanation
 

--- a/gptel-magit.el
+++ b/gptel-magit.el
@@ -124,8 +124,9 @@ Invokes CALLBACK with the generated message when done."
       :system gptel-magit-commit-prompt
       :context nil
       :callback (lambda (response _info)
-                  (let ((msg (gptel-magit--format-commit-message response)))
-                    (funcall callback msg))))))
+                  (when (stringp response)
+                    (let ((msg (gptel-magit--format-commit-message response)))
+                      (funcall callback msg)))))))
 
 (defun gptel-magit-generate-message ()
   "Generate a commit message when in the git commit buffer."
@@ -168,7 +169,8 @@ Uses ARGS from transient mode."
     :system gptel-magit-diff-explain-prompt
     :context nil
     :callback (lambda (response _info)
-                (gptel-magit--show-diff-explain response)))
+                (when (stringp response)
+                  (gptel-magit--show-diff-explain response))))
   (message "magit-gptel: Explaining diff..."))
 
 (defun gptel-magit-diff-explain ()

--- a/gptel-magit.el
+++ b/gptel-magit.el
@@ -105,6 +105,12 @@ See `gptel-backend` for documentation."
  :group 'gptel-magit)
 
 
+(defvar gptel-magit-rationale-buffer "*gptel-magit Rationale*"
+  "Buffer name for entering rationale for commit message generation.")
+
+(defvar gptel-magit--current-commit-buffer nil
+  "Buffer where commit message is being generated.")
+
 (defun gptel-magit--format-commit-message (message)
   "Format commit message MESSAGE nicely."
   (with-temp-buffer
@@ -136,11 +142,15 @@ Respects configured model/backend options."
          (gptel-model (or gptel-magit-model gptel-model)))
     (apply #'gptel-request args)))
 
-(defun gptel-magit--generate (callback)
+(defun gptel-magit--generate (callback &optional rationale)
   "Generate a commit message for current magit repo.
-Invokes CALLBACK with the generated message when done."
-  (let ((diff (magit-git-output "diff" "--cached")))
-    (gptel-magit--request diff
+Invokes CALLBACK with the generated message when done.
+Optional RATIONALE provides context for why the change was made."
+  (let* ((diff (magit-git-output "diff" "--cached"))
+         (prompt (if (and rationale (not (string-empty-p rationale)))
+                     (format "Why this change was made: %s\n\nCode changes:\n%s" rationale diff)
+                   diff)))
+    (gptel-magit--request prompt
       :system (gptel-magit--get-commit-prompt)
       :context nil
       :callback (lambda (response _info)
@@ -202,12 +212,102 @@ Uses ARGS from transient mode."
               (content (buffer-substring start end)))
     (gptel-magit--do-diff-request content)))
 
+(define-derived-mode gptel-magit-rationale-mode text-mode "gptel-magit-Rationale"
+  "Mode for entering commit rationale before generating commit message."
+  (local-set-key (kbd "C-c C-c") #'gptel-magit--submit-rationale)
+  (local-set-key (kbd "C-c C-k") #'gptel-magit--cancel-rationale))
+
+(defun gptel-magit--setup-rationale-buffer ()
+  "Setup the rationale buffer with proper guidance."
+  (let ((inhibit-read-only t))
+    (erase-buffer)
+    (insert ";;; WHY are you making these changes? (optional)\n")
+    (insert ";;; Press C-c C-c to generate commit message, C-c C-k to cancel\n")
+    (insert ";;; Leave empty to generate without rationale\n")
+    (insert ";;; ────────────────────────────────────────────────────────\n")
+    (add-text-properties (point-min) (point)
+                         '(face font-lock-comment-face read-only t))
+    (insert "\n")
+    (goto-char (point-max))))
+
+(defun gptel-magit--submit-rationale ()
+  "Submit the rationale buffer content and proceed with commit generation."
+  (interactive)
+  (let ((rationale (string-trim
+                    (buffer-substring-no-properties
+                     (save-excursion
+                       (goto-char (point-min))
+                       (while (and (not (eobp))
+                                   (get-text-property (point) 'read-only))
+                         (forward-char))
+                       (point))
+                     (point-max)))))
+    (quit-window t)
+    (gptel-magit--generate
+     (lambda (message)
+       (with-current-buffer gptel-magit--current-commit-buffer
+         (save-excursion
+           (goto-char (point-min))
+           (insert message))))
+     rationale)
+    (message "magit-gptel: Generating commit message with rationale...")))
+
+(defun gptel-magit--cancel-rationale ()
+  "Cancel rationale input and abort commit generation."
+  (interactive)
+  (quit-window t)
+  (message "Commit generation canceled."))
+
+(defun gptel-magit-generate-message-with-rationale ()
+  "Generate a commit message with rationale when in the git commit buffer."
+  (interactive)
+  (unless (magit-commit-message-buffer)
+    (user-error "No commit in progress"))
+  (setq gptel-magit--current-commit-buffer (magit-commit-message-buffer))
+  (let ((buffer (get-buffer-create gptel-magit-rationale-buffer)))
+    (with-current-buffer buffer
+      (gptel-magit-rationale-mode)
+      (gptel-magit--setup-rationale-buffer))
+    (pop-to-buffer buffer)))
+
+(defun gptel-magit-commit-generate-with-rationale (&optional args)
+  "Create a new commit with a generated commit message with rationale.
+Uses ARGS from transient mode."
+  (interactive (list (magit-commit-arguments)))
+  (setq gptel-magit--current-commit-buffer nil)
+  (let ((buffer (get-buffer-create gptel-magit-rationale-buffer)))
+    (with-current-buffer buffer
+      (gptel-magit-rationale-mode)
+      (gptel-magit--setup-rationale-buffer)
+      (local-set-key (kbd "C-c C-c")
+                     (lambda ()
+                       (interactive)
+                       (let ((rationale (string-trim
+                                         (buffer-substring-no-properties
+                                          (save-excursion
+                                            (goto-char (point-min))
+                                            (while (and (not (eobp))
+                                                        (get-text-property (point) 'read-only))
+                                              (forward-char))
+                                            (point))
+                                          (point-max)))))
+                         (quit-window t)
+                         (gptel-magit--generate
+                          (lambda (message)
+                            (magit-commit-create (append args `("--message" ,message "--edit"))))
+                          rationale)
+                         (message "magit-gptel: Generating commit with rationale...")))))
+    (pop-to-buffer buffer)))
+
 ;;;###autoload
 (defun gptel-magit-install ()
   "Install gptel-magit functionality."
   (define-key git-commit-mode-map (kbd "M-g") 'gptel-magit-generate-message)
+  (define-key git-commit-mode-map (kbd "M-r") 'gptel-magit-generate-message-with-rationale)
   (transient-append-suffix 'magit-commit #'magit-commit-create
     '("g" "Generate commit" gptel-magit-commit-generate))
+  (transient-append-suffix 'magit-commit #'gptel-magit-commit-generate
+    '("r" "Generate with rationale" gptel-magit-commit-generate-with-rationale))
   (transient-append-suffix 'magit-diff #'magit-stash-show
     '("x" "Explain" gptel-magit-diff-explain)))
 

--- a/gptel-magit.el
+++ b/gptel-magit.el
@@ -104,7 +104,9 @@ See `gptel-backend` for documentation."
     (insert message)
     (text-mode)
     (setq fill-column git-commit-summary-max-length)
-    (fill-region (point-min) (point-max))
+    (goto-char (point-min))
+    (let ((end-of-first-line (progn (end-of-line) (point))))
+      (fill-region (point-min) end-of-first-line))
     (buffer-string)))
 
 (defun gptel-magit--request (&rest args)

--- a/gptel-magit.el
+++ b/gptel-magit.el
@@ -153,10 +153,16 @@ Optional RATIONALE provides context for why the change was made."
     (gptel-magit--request prompt
       :system (gptel-magit--get-commit-prompt)
       :context nil
-      :callback (lambda (response _info)
-                  (when (stringp response)
+      :callback (lambda (response info)
+                  (cond
+                   ((stringp response)
                     (let ((msg (gptel-magit--format-commit-message response)))
-                      (funcall callback msg)))))))
+                      (funcall callback msg)))
+                   ((and (consp response) (eq (car response) 'reasoning))
+                    nil) ; silently ignore reasoning traces
+                   ((null response)
+                    (message "gptel-magit: Empty response from LLM (%s)"
+                             (or (plist-get info :status) "unknown status"))))))))
 
 (defun gptel-magit-generate-message ()
   "Generate a commit message when in the git commit buffer."
@@ -198,9 +204,15 @@ Uses ARGS from transient mode."
   (gptel-magit--request diff
     :system gptel-magit-diff-explain-prompt
     :context nil
-    :callback (lambda (response _info)
-                (when (stringp response)
-                  (gptel-magit--show-diff-explain response))))
+    :callback (lambda (response info)
+                (cond
+                 ((stringp response)
+                  (gptel-magit--show-diff-explain response))
+                 ((and (consp response) (eq (car response) 'reasoning))
+                  nil)
+                 ((null response)
+                  (message "gptel-magit: Empty response from LLM (%s)"
+                           (or (plist-get info :status) "unknown status"))))))
   (message "magit-gptel: Explaining diff..."))
 
 (defun gptel-magit-diff-explain ()

--- a/gptel-magit.el
+++ b/gptel-magit.el
@@ -55,13 +55,19 @@ The commit message should be structured as follows:
 - An optional scope MAY be provided after a type. A scope is a phrase describing a section of the codebase enclosed in parenthesis, e.g., fix(parser):
 - A description MUST immediately follow the type/scope prefix. The description is a short description of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.
 - Try to limit the whole subject line to 60 characters
-- Try to limit the body line number to 72 characters
 - Capitalize the subject line
 - Do not end the subject line with any punctuation
 - A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.
 - Use the imperative mood in the subject line
 - Keep the body short and concise (omit it entirely if not useful)"
   "A prompt adapted from Conventional Commits (https://www.conventionalcommits.org/en/v1.0.0/).")
+
+(defcustom gptel-magit-body-length nil
+  "Maximum character length for commit message body lines.
+If nil, no body length constraint is mentioned in the prompt."
+  :type '(choice (const :tag "No constraint" nil)
+                 (integer :tag "Character limit"))
+  :group 'gptel-magit)
 
 (defcustom gptel-magit-commit-prompt
   gptel-magit-prompt-conventional-commits
@@ -110,6 +116,17 @@ See `gptel-backend` for documentation."
       (fill-region (point-min) end-of-first-line))
     (buffer-string)))
 
+(defun gptel-magit--get-commit-prompt ()
+  "Get the commit prompt, potentially modified based on configuration."
+  (cond
+   ;; If using conventional commits and body length is set, append the body length line
+   ((and (string= gptel-magit-commit-prompt gptel-magit-prompt-conventional-commits)
+         gptel-magit-body-length)
+    (concat gptel-magit-prompt-conventional-commits
+            (format "\n- Try to limit the body line number to %d characters" gptel-magit-body-length)))
+   ;; For all other cases, use the prompt as-is
+   (t gptel-magit-commit-prompt)))
+
 (defun gptel-magit--request (&rest args)
   "Call `gptel-request` with ARGS.
 
@@ -124,7 +141,7 @@ Respects configured model/backend options."
 Invokes CALLBACK with the generated message when done."
   (let ((diff (magit-git-output "diff" "--cached")))
     (gptel-magit--request diff
-      :system gptel-magit-commit-prompt
+      :system (gptel-magit--get-commit-prompt)
       :context nil
       :callback (lambda (response _info)
                   (let ((msg (gptel-magit--format-commit-message response)))

--- a/gptel-magit.el
+++ b/gptel-magit.el
@@ -55,6 +55,7 @@ The commit message should be structured as follows:
 - An optional scope MAY be provided after a type. A scope is a phrase describing a section of the codebase enclosed in parenthesis, e.g., fix(parser):
 - A description MUST immediately follow the type/scope prefix. The description is a short description of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.
 - Try to limit the whole subject line to 60 characters
+- Try to limit the body line number to 72 characters
 - Capitalize the subject line
 - Do not end the subject line with any punctuation
 - A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.

--- a/gptel-magit.el
+++ b/gptel-magit.el
@@ -12,7 +12,7 @@
 ;;; Commentary:
 
 ;; This package uses the gptel library to add LLM integration into
-;; magit. Currently, it adds functionality for generating commit
+;; magit.  Currently, it adds functionality for generating commit
 ;; messages.
 
 ;;; Code:
@@ -142,6 +142,33 @@ Respects configured model/backend options."
          (gptel-model (or gptel-magit-model gptel-model)))
     (apply #'gptel-request args)))
 
+(defun gptel-magit--streaming-callback (callback &optional what transform)
+  "Return a gptel streaming callback for CALLBACK.
+Call CALLBACK once, after all streaming chunks arrive.  WHAT is
+used in diagnostic messages.  TRANSFORM, when non-nil, is applied
+to the completed response before CALLBACK is called."
+  (let ((chunks nil)
+        (what (or what "response")))
+    (lambda (response info)
+      (cond
+       ((and (stringp response) (plist-get info :stream))
+        (push response chunks))
+       ((stringp response)
+        (funcall callback (if transform (funcall transform response) response)))
+       ((eq response t)
+        (let ((text (apply #'concat (nreverse chunks))))
+          (funcall callback (if transform (funcall transform text) text))))
+       ((and (consp response) (eq (car response) 'reasoning))
+        nil)
+       ((plist-get info :error)
+        (message "gptel-magit: Error generating %s: %s"
+                 what
+                 (or (plist-get (plist-get info :error) :message)
+                     (plist-get info :error))))
+       ((null response)
+        (message "gptel-magit: Empty %s from LLM (%s)"
+                 what (or (plist-get info :status) "unknown status")))))))
+
 (defun gptel-magit--generate (callback &optional rationale)
   "Generate a commit message for current magit repo.
 Invokes CALLBACK with the generated message when done.
@@ -153,16 +180,9 @@ Optional RATIONALE provides context for why the change was made."
     (gptel-magit--request prompt
       :system (gptel-magit--get-commit-prompt)
       :context nil
-      :callback (lambda (response info)
-                  (cond
-                   ((stringp response)
-                    (let ((msg (gptel-magit--format-commit-message response)))
-                      (funcall callback msg)))
-                   ((and (consp response) (eq (car response) 'reasoning))
-                    nil) ; silently ignore reasoning traces
-                   ((null response)
-                    (message "gptel-magit: Empty response from LLM (%s)"
-                             (or (plist-get info :status) "unknown status"))))))))
+      :stream t
+      :callback (gptel-magit--streaming-callback
+                 callback "commit message" #'gptel-magit--format-commit-message))))
 
 (defun gptel-magit-generate-message ()
   "Generate a commit message when in the git commit buffer."
@@ -204,15 +224,9 @@ Uses ARGS from transient mode."
   (gptel-magit--request diff
     :system gptel-magit-diff-explain-prompt
     :context nil
-    :callback (lambda (response info)
-                (cond
-                 ((stringp response)
-                  (gptel-magit--show-diff-explain response))
-                 ((and (consp response) (eq (car response) 'reasoning))
-                  nil)
-                 ((null response)
-                  (message "gptel-magit: Empty response from LLM (%s)"
-                           (or (plist-get info :status) "unknown status"))))))
+    :stream t
+    :callback (gptel-magit--streaming-callback
+               #'gptel-magit--show-diff-explain "diff explanation"))
   (message "magit-gptel: Explaining diff..."))
 
 (defun gptel-magit-diff-explain ()

--- a/gptel-magit.el
+++ b/gptel-magit.el
@@ -17,8 +17,10 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'gptel)
 (require 'magit)
+(require 'subr-x)
 
 (defconst gptel-magit-prompt-zed
   "You are an expert at writing Git commits. Your job is to write a short clear commit message that summarizes the changes.
@@ -84,6 +86,19 @@ The prompt should consider that the input will be a diff some changes."
   :type 'string
   :group 'gptel-magit)
 
+(defcustom gptel-magit-tag-prompt
+  "You are an expert at writing annotated Git tag messages.
+Your job is to write a clear, concise release summary for the changes between a previous tag and the new tag target.
+
+Use the supplied commit list, diffstat, and diff to identify the notable changes. Prefer a short title followed by concise bullet points when useful.
+
+Only return the tag message. Do not include any additional meta-commentary about the task. Do not include the raw diff output in the tag message."
+  "The prompt to use for generating annotated tag messages.
+The input contains the previous tag, the new tag target, commit
+subjects, a diffstat, and the diff between those revisions."
+  :type 'string
+  :group 'gptel-magit)
+
 (custom-declare-variable
  'gptel-magit-model nil
  "The gptel model to use, defaults to `gptel-model` if nil.
@@ -110,6 +125,9 @@ See `gptel-backend` for documentation."
 
 (defvar gptel-magit--current-commit-buffer nil
   "Buffer where commit message is being generated.")
+
+(defvar-local gptel-magit--rationale-submit-function nil
+  "Function called with rationale text from `gptel-magit-rationale-mode'.")
 
 (defun gptel-magit--format-commit-message (message)
   "Format commit message MESSAGE nicely."
@@ -184,17 +202,141 @@ Optional RATIONALE provides context for why the change was made."
       :callback (gptel-magit--streaming-callback
                  callback "commit message" #'gptel-magit--format-commit-message))))
 
+(defun gptel-magit--tag-message-buffer-p ()
+  "Return non-nil if the current buffer edits a Git tag message."
+  (and buffer-file-name
+       (string= (file-name-nondirectory buffer-file-name) "TAG_EDITMSG")))
+
+(defun gptel-magit--format-tag-message (message)
+  "Format generated tag MESSAGE for insertion."
+  (concat (string-trim-right message) "\n"))
+
+(defun gptel-magit--insert-message-at-top (message)
+  "Insert MESSAGE at the top of the current message buffer."
+  (save-excursion
+    (goto-char (point-min))
+    (insert (string-trim-right message) "\n\n")))
+
+(defun gptel-magit--read-previous-tag (target)
+  "Read the previous tag to compare against TARGET."
+  (magit-completing-read
+   (format "Previous tag for %s" target)
+   (magit-list-tags) nil t nil 'magit-revision-history
+   (magit-get-current-tag target)))
+
+(defun gptel-magit--read-tag-generation-args (&optional args)
+  "Read arguments needed to create a generated annotated tag.
+ARGS are the active `magit-tag' transient arguments."
+  (let* ((args (or args (magit-tag-arguments)))
+         (tag (magit-completing-read "Create tag" (magit-list-tags)))
+         (target (magit-read-branch-or-commit "Place tag on"))
+         (previous (gptel-magit--read-previous-tag target)))
+    (list tag target previous args)))
+
+(defun gptel-magit--tag-request-text (previous target tag rationale)
+  "Build the tag-generation request for PREVIOUS..TARGET.
+TAG is the tag being generated, or nil when generating inside an
+existing tag message buffer.  Optional RATIONALE provides extra
+user context."
+  (let* ((range (format "%s..%s" previous target))
+         (commits (magit-git-output "log" "--reverse" "--format=%h %s" range))
+         (stat (magit-git-output "diff" "--stat" previous target))
+         (diff (magit-git-output "diff" previous target)))
+    (concat
+     (and tag (format "New tag: %s\n" tag))
+     (format "Previous tag: %s\nNew tag target: %s\nRange: %s\n\n"
+             previous target range)
+     (and (and rationale (not (string-empty-p rationale)))
+          (format "Release rationale: %s\n\n" rationale))
+     "Commits:\n" commits "\n\n"
+     "Diffstat:\n" stat "\n\n"
+     "Diff:\n" diff)))
+
+(defun gptel-magit--generate-tag-message (previous target callback
+                                                   &optional tag rationale)
+  "Generate a tag message for PREVIOUS..TARGET.
+Invoke CALLBACK with the generated message.  Optional TAG is the
+new tag name, and optional RATIONALE gives user context."
+  (gptel-magit--request
+      (gptel-magit--tag-request-text previous target tag rationale)
+    :system gptel-magit-tag-prompt
+    :context nil
+    :stream t
+    :callback (gptel-magit--streaming-callback
+               callback "tag message" #'gptel-magit--format-tag-message)))
+
+(defun gptel-magit--tag-annotated-arg-p (arg)
+  "Return non-nil if ARG requests an annotated tag."
+  (and (stringp arg)
+       (string-match-p "\\`--\\(annotate\\|sign\\|local-user\\)" arg)))
+
+(defun gptel-magit--tag-create-with-message (tag target previous args
+                                                 &optional rationale)
+  "Create TAG at TARGET using a generated message since PREVIOUS.
+ARGS are the active `magit-tag' transient arguments.  Optional
+RATIONALE provides extra context for generation."
+  (let ((args (copy-sequence args)))
+    (unless (cl-some #'gptel-magit--tag-annotated-arg-p args)
+      (cl-pushnew "--annotate" args :test #'equal))
+    (cl-pushnew "--edit" args :test #'equal)
+    (gptel-magit--generate-tag-message
+     previous target
+     (lambda (message)
+       (magit-run-git-with-editor "tag" args (list "-m" message) tag target))
+     tag rationale))
+  (message "magit-gptel: Generating tag message..."))
+
+(defun gptel-magit--generate-tag-message-in-buffer (&optional rationale)
+  "Generate a tag message into the current tag edit buffer.
+Optional RATIONALE provides extra context for generation.  The tag
+target defaults to HEAD because Git does not expose the pending tag
+object in TAG_EDITMSG."
+  (let* ((buffer (current-buffer))
+         (target "HEAD")
+         (previous (gptel-magit--read-previous-tag target)))
+    (gptel-magit--generate-tag-message
+     previous target
+     (lambda (message)
+       (when (buffer-live-p buffer)
+         (with-current-buffer buffer
+           (gptel-magit--insert-message-at-top message))))
+     nil rationale))
+  (message "magit-gptel: Generating tag message..."))
+
+(defun gptel-magit-tag-generate (&optional args)
+  "Create an annotated tag with a generated tag message.
+Uses ARGS from the `magit-tag' transient."
+  (interactive (list (magit-tag-arguments)))
+  (pcase-let ((`(,tag ,target ,previous ,args)
+               (gptel-magit--read-tag-generation-args args)))
+    (gptel-magit--tag-create-with-message tag target previous args)))
+
+(defun gptel-magit-tag-generate-with-rationale (&optional args)
+  "Create an annotated tag with a generated tag message and rationale.
+Uses ARGS from the `magit-tag' transient."
+  (interactive (list (magit-tag-arguments)))
+  (pcase-let ((`(,tag ,target ,previous ,args)
+               (gptel-magit--read-tag-generation-args args)))
+    (gptel-magit--prompt-for-rationale
+     (lambda (rationale)
+       (gptel-magit--tag-create-with-message
+        tag target previous args rationale)))))
+
 (defun gptel-magit-generate-message ()
-  "Generate a commit message when in the git commit buffer."
+  "Generate a commit or tag message in a Git message buffer."
   (interactive)
-  (unless (magit-commit-message-buffer)
-    (user-error "No commit in progress"))
-  (gptel-magit--generate (lambda (message)
-                           (with-current-buffer (magit-commit-message-buffer)
-                             (save-excursion
-                               (goto-char (point-min))
-                               (insert message)))))
-  (message "magit-gptel: Generating commit message..."))
+  (cond
+   ((gptel-magit--tag-message-buffer-p)
+    (gptel-magit--generate-tag-message-in-buffer))
+   ((magit-commit-message-buffer)
+    (gptel-magit--generate (lambda (message)
+                             (with-current-buffer (magit-commit-message-buffer)
+                               (save-excursion
+                                 (goto-char (point-min))
+                                 (insert message)))))
+    (message "magit-gptel: Generating commit message..."))
+   (t
+    (user-error "No commit or tag message in progress"))))
 
 (defun gptel-magit-commit-generate (&optional args)
   "Create a new commit with a generated commit message.
@@ -245,10 +387,11 @@ Uses ARGS from transient mode."
 
 (defun gptel-magit--setup-rationale-buffer ()
   "Setup the rationale buffer with proper guidance."
+  (setq-local gptel-magit--rationale-submit-function nil)
   (let ((inhibit-read-only t))
     (erase-buffer)
     (insert ";;; WHY are you making these changes? (optional)\n")
-    (insert ";;; Press C-c C-c to generate commit message, C-c C-k to cancel\n")
+    (insert ";;; Press C-c C-c to generate message, C-c C-k to cancel\n")
     (insert ";;; Leave empty to generate without rationale\n")
     (insert ";;; ────────────────────────────────────────────────────────\n")
     (add-text-properties (point-min) (point)
@@ -256,8 +399,17 @@ Uses ARGS from transient mode."
     (insert "\n")
     (goto-char (point-max))))
 
+(defun gptel-magit--prompt-for-rationale (submit-function)
+  "Prompt for rationale and call SUBMIT-FUNCTION with the result."
+  (let ((buffer (get-buffer-create gptel-magit-rationale-buffer)))
+    (with-current-buffer buffer
+      (gptel-magit-rationale-mode)
+      (gptel-magit--setup-rationale-buffer)
+      (setq-local gptel-magit--rationale-submit-function submit-function))
+    (pop-to-buffer buffer)))
+
 (defun gptel-magit--submit-rationale ()
-  "Submit the rationale buffer content and proceed with commit generation."
+  "Submit the rationale buffer content and proceed with generation."
   (interactive)
   (let ((rationale (string-trim
                     (buffer-substring-no-properties
@@ -267,16 +419,19 @@ Uses ARGS from transient mode."
                                    (get-text-property (point) 'read-only))
                          (forward-char))
                        (point))
-                     (point-max)))))
+                     (point-max))))
+        (submit-function gptel-magit--rationale-submit-function))
     (quit-window t)
-    (gptel-magit--generate
-     (lambda (message)
-       (with-current-buffer gptel-magit--current-commit-buffer
-         (save-excursion
-           (goto-char (point-min))
-           (insert message))))
-     rationale)
-    (message "magit-gptel: Generating commit message with rationale...")))
+    (if submit-function
+        (funcall submit-function rationale)
+      (gptel-magit--generate
+       (lambda (message)
+         (with-current-buffer gptel-magit--current-commit-buffer
+           (save-excursion
+             (goto-char (point-min))
+             (insert message))))
+       rationale)
+      (message "magit-gptel: Generating commit message with rationale..."))))
 
 (defun gptel-magit--cancel-rationale ()
   "Cancel rationale input and abort commit generation."
@@ -285,16 +440,25 @@ Uses ARGS from transient mode."
   (message "Commit generation canceled."))
 
 (defun gptel-magit-generate-message-with-rationale ()
-  "Generate a commit message with rationale when in the git commit buffer."
+  "Generate a commit or tag message with rationale."
   (interactive)
-  (unless (magit-commit-message-buffer)
-    (user-error "No commit in progress"))
-  (setq gptel-magit--current-commit-buffer (magit-commit-message-buffer))
-  (let ((buffer (get-buffer-create gptel-magit-rationale-buffer)))
-    (with-current-buffer buffer
-      (gptel-magit-rationale-mode)
-      (gptel-magit--setup-rationale-buffer))
-    (pop-to-buffer buffer)))
+  (cond
+   ((gptel-magit--tag-message-buffer-p)
+    (let ((buffer (current-buffer)))
+      (gptel-magit--prompt-for-rationale
+       (lambda (rationale)
+         (when (buffer-live-p buffer)
+           (with-current-buffer buffer
+             (gptel-magit--generate-tag-message-in-buffer rationale)))))))
+   ((magit-commit-message-buffer)
+    (setq gptel-magit--current-commit-buffer (magit-commit-message-buffer))
+    (let ((buffer (get-buffer-create gptel-magit-rationale-buffer)))
+      (with-current-buffer buffer
+        (gptel-magit-rationale-mode)
+        (gptel-magit--setup-rationale-buffer))
+      (pop-to-buffer buffer)))
+   (t
+    (user-error "No commit or tag message in progress"))))
 
 (defun gptel-magit-commit-generate-with-rationale (&optional args)
   "Create a new commit with a generated commit message with rationale.
@@ -334,6 +498,10 @@ Uses ARGS from transient mode."
     '("g" "Generate commit" gptel-magit-commit-generate))
   (transient-append-suffix 'magit-commit #'gptel-magit-commit-generate
     '("r" "Generate with rationale" gptel-magit-commit-generate-with-rationale))
+  (transient-append-suffix 'magit-tag #'magit-tag-create
+    '("g" "Generate tag" gptel-magit-tag-generate))
+  (transient-append-suffix 'magit-tag #'gptel-magit-tag-generate
+    '("R" "Generate with rationale" gptel-magit-tag-generate-with-rationale))
   (transient-append-suffix 'magit-diff #'magit-stash-show
     '("x" "Explain" gptel-magit-diff-explain)))
 


### PR DESCRIPTION
- Only format the commit summary, not the whole commit
- Add a body line length option in the prompt for gptel-magit-prompt-conventional-commits