### PR TITLE
feat(rationale): Add optional rationale input for commit generation

### DIFF
--- a/gptel-magit.el
+++ b/gptel-magit.el
@@ -124,8 +124,9 @@ Invokes CALLBACK with the generated message when done."
       :system gptel-magit-commit-prompt
       :context nil
       :callback (lambda (response _info)
-                  (let ((msg (gptel-magit--format-commit-message response)))
-                    (funcall callback msg))))))
+                  (when (stringp response)
+                    (let ((msg (gptel-magit--format-commit-message response)))
+                      (funcall callback msg)))))))
 
 (defun gptel-magit-generate-message ()
   "Generate a commit message when in the git commit buffer."
@@ -168,7 +169,8 @@ Uses ARGS from transient mode."
     :system gptel-magit-diff-explain-prompt
     :context nil
     :callback (lambda (response _info)
-                (gptel-magit--show-diff-explain response)))
+                (when (stringp response)
+                  (gptel-magit--show-diff-explain response))))
   (message "magit-gptel: Explaining diff..."))
 
 (defun gptel-magit-diff-explain ()

--- a/gptel-magit.el
+++ b/gptel-magit.el
@@ -105,6 +105,12 @@ See `gptel-backend` for documentation."
  :group 'gptel-magit)
 
 
+(defvar gptel-magit-rationale-buffer "*gptel-magit Rationale*"
+  "Buffer name for entering rationale for commit message generation.")
+
+(defvar gptel-magit--current-commit-buffer nil
+  "Buffer where commit message is being generated.")
+
 (defun gptel-magit--format-commit-message (message)
   "Format commit message MESSAGE nicely."
   (with-temp-buffer
@@ -136,11 +142,15 @@ Respects configured model/backend options."
          (gptel-model (or gptel-magit-model gptel-model)))
     (apply #'gptel-request args)))
 
-(defun gptel-magit--generate (callback)
+(defun gptel-magit--generate (callback &optional rationale)
   "Generate a commit message for current magit repo.
-Invokes CALLBACK with the generated message when done."
-  (let ((diff (magit-git-output "diff" "--cached")))
-    (gptel-magit--request diff
+Invokes CALLBACK with the generated message when done.
+Optional RATIONALE provides context for why the change was made."
+  (let* ((diff (magit-git-output "diff" "--cached"))
+         (prompt (if (and rationale (not (string-empty-p rationale)))
+                     (format "Why this change was made: %s\n\nCode changes:\n%s" rationale diff)
+                   diff)))
+    (gptel-magit--request prompt
       :system (gptel-magit--get-commit-prompt)
       :context nil
       :callback (lambda (response _info)
@@ -202,12 +212,102 @@ Uses ARGS from transient mode."
               (content (buffer-substring start end)))
     (gptel-magit--do-diff-request content)))
 
+(define-derived-mode gptel-magit-rationale-mode text-mode "gptel-magit-Rationale"
+  "Mode for entering commit rationale before generating commit message."
+  (local-set-key (kbd "C-c C-c") #'gptel-magit--submit-rationale)
+  (local-set-key (kbd "C-c C-k") #'gptel-magit--cancel-rationale))
+
+(defun gptel-magit--setup-rationale-buffer ()
+  "Setup the rationale buffer with proper guidance."
+  (let ((inhibit-read-only t))
+    (erase-buffer)
+    (insert ";;; WHY are you making these changes? (optional)\n")
+    (insert ";;; Press C-c C-c to generate commit message, C-c C-k to cancel\n")
+    (insert ";;; Leave empty to generate without rationale\n")
+    (insert ";;; ────────────────────────────────────────────────────────\n")
+    (add-text-properties (point-min) (point)
+                         '(face font-lock-comment-face read-only t))
+    (insert "\n")
+    (goto-char (point-max))))
+
+(defun gptel-magit--submit-rationale ()
+  "Submit the rationale buffer content and proceed with commit generation."
+  (interactive)
+  (let ((rationale (string-trim
+                    (buffer-substring-no-properties
+                     (save-excursion
+                       (goto-char (point-min))
+                       (while (and (not (eobp))
+                                   (get-text-property (point) 'read-only))
+                         (forward-char))
+                       (point))
+                     (point-max)))))
+    (quit-window t)
+    (gptel-magit--generate
+     (lambda (message)
+       (with-current-buffer gptel-magit--current-commit-buffer
+         (save-excursion
+           (goto-char (point-min))
+           (insert message))))
+     rationale)
+    (message "magit-gptel: Generating commit message with rationale...")))
+
+(defun gptel-magit--cancel-rationale ()
+  "Cancel rationale input and abort commit generation."
+  (interactive)
+  (quit-window t)
+  (message "Commit generation canceled."))
+
+(defun gptel-magit-generate-message-with-rationale ()
+  "Generate a commit message with rationale when in the git commit buffer."
+  (interactive)
+  (unless (magit-commit-message-buffer)
+    (user-error "No commit in progress"))
+  (setq gptel-magit--current-commit-buffer (magit-commit-message-buffer))
+  (let ((buffer (get-buffer-create gptel-magit-rationale-buffer)))
+    (with-current-buffer buffer
+      (gptel-magit-rationale-mode)
+      (gptel-magit--setup-rationale-buffer))
+    (pop-to-buffer buffer)))
+
+(defun gptel-magit-commit-generate-with-rationale (&optional args)
+  "Create a new commit with a generated commit message with rationale.
+Uses ARGS from transient mode."
+  (interactive (list (magit-commit-arguments)))
+  (setq gptel-magit--current-commit-buffer nil)
+  (let ((buffer (get-buffer-create gptel-magit-rationale-buffer)))
+    (with-current-buffer buffer
+      (gptel-magit-rationale-mode)
+      (gptel-magit--setup-rationale-buffer)
+      (local-set-key (kbd "C-c C-c")
+                     (lambda ()
+                       (interactive)
+                       (let ((rationale (string-trim
+                                         (buffer-substring-no-properties
+                                          (save-excursion
+                                            (goto-char (point-min))
+                                            (while (and (not (eobp))
+                                                        (get-text-property (point) 'read-only))
+                                              (forward-char))
+                                            (point))
+                                          (point-max)))))
+                         (quit-window t)
+                         (gptel-magit--generate
+                          (lambda (message)
+                            (magit-commit-create (append args `("--message" ,message "--edit"))))
+                          rationale)
+                         (message "magit-gptel: Generating commit with rationale...")))))
+    (pop-to-buffer buffer)))
+
 ;;;###autoload
 (defun gptel-magit-install ()
   "Install gptel-magit functionality."
   (define-key git-commit-mode-map (kbd "M-g") 'gptel-magit-generate-message)
+  (define-key git-commit-mode-map (kbd "M-r") 'gptel-magit-generate-message-with-rationale)
   (transient-append-suffix 'magit-commit #'magit-commit-create
     '("g" "Generate commit" gptel-magit-commit-generate))
+  (transient-append-suffix 'magit-commit #'gptel-magit-commit-generate
+    '("r" "Generate with rationale" gptel-magit-commit-generate-with-rationale))
   (transient-append-suffix 'magit-diff #'magit-stash-show
     '("x" "Explain" gptel-magit-diff-explain)))
 

--- a/gptel-magit.el
+++ b/gptel-magit.el
@@ -104,7 +104,9 @@ See `gptel-backend` for documentation."
     (insert message)
     (text-mode)
     (setq fill-column git-commit-summary-max-length)
-    (fill-region (point-min) (point-max))
+    (goto-char (point-min))
+    (let ((end-of-first-line (progn (end-of-line) (point))))
+      (fill-region (point-min) end-of-first-line))
     (buffer-string)))
 
 (defun gptel-magit--request (&rest args)

--- a/gptel-magit.el
+++ b/gptel-magit.el
@@ -153,10 +153,16 @@ Optional RATIONALE provides context for why the change was made."
     (gptel-magit--request prompt
       :system (gptel-magit--get-commit-prompt)
       :context nil
-      :callback (lambda (response _info)
-                  (when (stringp response)
+      :callback (lambda (response info)
+                  (cond
+                   ((stringp response)
                     (let ((msg (gptel-magit--format-commit-message response)))
-                      (funcall callback msg)))))))
+                      (funcall callback msg)))
+                   ((and (consp response) (eq (car response) 'reasoning))
+                    nil) ; silently ignore reasoning traces
+                   ((null response)
+                    (message "gptel-magit: Empty response from LLM (%s)"
+                             (or (plist-get info :status) "unknown status"))))))))
 
 (defun gptel-magit-generate-message ()
   "Generate a commit message when in the git commit buffer."
@@ -198,9 +204,15 @@ Uses ARGS from transient mode."
   (gptel-magit--request diff
     :system gptel-magit-diff-explain-prompt
     :context nil
-    :callback (lambda (response _info)
-                (when (stringp response)
-                  (gptel-magit--show-diff-explain response))))
+    :callback (lambda (response info)
+                (cond
+                 ((stringp response)
+                  (gptel-magit--show-diff-explain response))
+                 ((and (consp response) (eq (car response) 'reasoning))
+                  nil)
+                 ((null response)
+                  (message "gptel-magit: Empty response from LLM (%s)"
+                           (or (plist-get info :status) "unknown status"))))))
   (message "magit-gptel: Explaining diff..."))
 
 (defun gptel-magit-diff-explain ()

--- a/gptel-magit.el
+++ b/gptel-magit.el
@@ -55,13 +55,19 @@ The commit message should be structured as follows:
 - An optional scope MAY be provided after a type. A scope is a phrase describing a section of the codebase enclosed in parenthesis, e.g., fix(parser):
 - A description MUST immediately follow the type/scope prefix. The description is a short description of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.
 - Try to limit the whole subject line to 60 characters
-- Try to limit the body line number to 72 characters
 - Capitalize the subject line
 - Do not end the subject line with any punctuation
 - A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.
 - Use the imperative mood in the subject line
 - Keep the body short and concise (omit it entirely if not useful)"
   "A prompt adapted from Conventional Commits (https://www.conventionalcommits.org/en/v1.0.0/).")
+
+(defcustom gptel-magit-body-length nil
+  "Maximum character length for commit message body lines.
+If nil, no body length constraint is mentioned in the prompt."
+  :type '(choice (const :tag "No constraint" nil)
+                 (integer :tag "Character limit"))
+  :group 'gptel-magit)
 
 (defcustom gptel-magit-commit-prompt
   gptel-magit-prompt-conventional-commits
@@ -110,6 +116,17 @@ See `gptel-backend` for documentation."
       (fill-region (point-min) end-of-first-line))
     (buffer-string)))
 
+(defun gptel-magit--get-commit-prompt ()
+  "Get the commit prompt, potentially modified based on configuration."
+  (cond
+   ;; If using conventional commits and body length is set, append the body length line
+   ((and (string= gptel-magit-commit-prompt gptel-magit-prompt-conventional-commits)
+         gptel-magit-body-length)
+    (concat gptel-magit-prompt-conventional-commits
+            (format "\n- Try to limit the body line number to %d characters" gptel-magit-body-length)))
+   ;; For all other cases, use the prompt as-is
+   (t gptel-magit-commit-prompt)))
+
 (defun gptel-magit--request (&rest args)
   "Call `gptel-request` with ARGS.
 
@@ -124,7 +141,7 @@ Respects configured model/backend options."
 Invokes CALLBACK with the generated message when done."
   (let ((diff (magit-git-output "diff" "--cached")))
     (gptel-magit--request diff
-      :system gptel-magit-commit-prompt
+      :system (gptel-magit--get-commit-prompt)
       :context nil
       :callback (lambda (response _info)
                   (let ((msg (gptel-magit--format-commit-message response)))

--- a/gptel-magit.el
+++ b/gptel-magit.el
@@ -55,6 +55,7 @@ The commit message should be structured as follows:
 - An optional scope MAY be provided after a type. A scope is a phrase describing a section of the codebase enclosed in parenthesis, e.g., fix(parser):
 - A description MUST immediately follow the type/scope prefix. The description is a short description of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.
 - Try to limit the whole subject line to 60 characters
+- Try to limit the body line number to 72 characters
 - Capitalize the subject line
 - Do not end the subject line with any punctuation
 - A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.


### PR DESCRIPTION
Add ability to provide context about why changes were made before
generating commit messages. Users can now enter a rationale explaining
the motivation behind their changes, which is included in the prompt
to the LLM for more contextual commit messages.

- Add new interactive commands for rationale-based generation
- Create dedicated rationale input buffer with guidance
- Add keybindings: M-r in commit mode, 'r' in magit-commit transient
- Support both standalone and integrated commit workflows

Idea from https://github.com/lakkiy/gptel-commit
