### PR TITLE
Enabling magit re-wording commit messages by adding the appropriate git command

### DIFF
--- a/gptel-magit.el
+++ b/gptel-magit.el
@@ -121,7 +121,7 @@ Respects configured model/backend options."
 Invokes CALLBACK with the generated message when done."
   (let* ((diff (magit-git-output "diff" "--cached"))
          (diff (if (string-empty-p diff)
-                   (magit-git-output "show")
+                   (magit-git-output "diff" "head~..head")
                  diff)))
     (gptel-magit--request diff
       :system gptel-magit-commit-prompt

--- a/gptel-magit.el
+++ b/gptel-magit.el
@@ -119,7 +119,10 @@ Respects configured model/backend options."
 (defun gptel-magit--generate (callback)
   "Generate a commit message for current magit repo.
 Invokes CALLBACK with the generated message when done."
-  (let ((diff (magit-git-output "diff" "--cached")))
+  (let* ((diff (magit-git-output "diff" "--cached"))
+         (diff (if (string-empty-p diff)
+                   (magit-git-output "show")
+                 diff)))
     (gptel-magit--request diff
       :system gptel-magit-commit-prompt
       :context nil


### PR DESCRIPTION
Committed changes (`git diff --cached`) are typically used.

For re-wording, even though magit shows the original diff, the git command returns an empty string so there is no context for gptel. The solution is calling `git show` to collecte the changes introduced in HEAD for gptel to use.

This enables gptel-magit to work when re-wording commits.