### PR TITLE
Fixing fill region issues due to missing markdown-mode setting

### DIFF
--- a/gptel-magit.el
+++ b/gptel-magit.el
@@ -102,7 +102,7 @@ See `gptel-backend` for documentation."
   "Format commit message MESSAGE nicely."
   (with-temp-buffer
     (insert message)
-    (text-mode)
+    (markdown-mode)
     (setq fill-column git-commit-summary-max-length)
     (fill-region (point-min) (point-max))
     (buffer-string)))


### PR DESCRIPTION
Notice that `fill-region` is mode-dependent. Often the generated message includes itemized list which could be filled wrongly like this:

```
- Sentence number one Sentence
- number two
```

Setting the draft buffer to be markdown-mode makes this filling style-aware and correct.

Additionally, it has no real impact if the user uses other modes for writing the commits (by modifying `git-commit-major-mode`) because it is used in a draft buffer and the mode only impacts the filling.